### PR TITLE
Add an env variable to disable SSL

### DIFF
--- a/api.js
+++ b/api.js
@@ -30,7 +30,7 @@ var sessions_settings_object = {
     activeDuration: 1000 * 60 * 5, // Extend for five minutes if actively used
     cookie: {
         httpOnly: true,
-        secure: true
+        secure: process.env.SSL_ENABLE === 'true'
     }
 }
 function session_wrapper_function(req, res, next) {
@@ -48,7 +48,6 @@ async function set_up_api_server(app) {
     if (!session_secret_setting) {
     	console.error(`No session secret is set, can't start API server (this really shouldn't happen...)!`);
     	throw new Error('NO_SESSION_SECRET_SET');
-    	return
     }
 
     const updated_session_settings = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       # SSL will automatically be set up and
       #  renewed with LetsEncrypt.
       - HOSTNAME=your.host.name
-      # [REQUIRED] Email for SSL
+      - SSL_ENABLED=true
+      # [REQUIRED if SSL_ENABLED] Email for SSL
       - SSL_CONTACT_EMAIL=YourEmail@gmail.com
       # Maximum XSS callback payload size
       # This includes the webpage screenshot, DOM HTML,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ $ENABLE_SSL = 'true' ]]; then
+if [[ $SSL_ENABLED = 'true' ]]; then
   echo "Initializing SSL/TLS..."
   # Set up Greenlock
   # Test if --maintainer-email is required, we can set it via environment variables...

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-echo "Initializing SSL/TLS..."
-# Set up Greenlock
-# Test if --maintainer-email is required, we can set it via environment variables...
-npx greenlock init --config-dir /app/greenlock.d --maintainer-email $SSL_CONTACT_EMAIL
-npx greenlock add --subject $HOSTNAME --altnames "$HOSTNAME"
+
+if [[ $ENABLE_SSL = 'true' ]]; then
+  echo "Initializing SSL/TLS..."
+  # Set up Greenlock
+  # Test if --maintainer-email is required, we can set it via environment variables...
+  npx greenlock init --config-dir /app/greenlock.d --maintainer-email $SSL_CONTACT_EMAIL
+  npx greenlock add --subject $HOSTNAME --altnames "$HOSTNAME"
+else
+  echo "Skipping SSL initialization"
+fi
 
 echo "Starting server..."
 node server.js

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const get_app_server = require('./app.js');
 const database = require('./database.js');
 const database_init = database.database_init;
 
-if(!process.env.SSL_CONTACT_EMAIL) {
+if(process.env.SSL_ENABLED === 'true' && !process.env.SSL_CONTACT_EMAIL) {
     console.error(`[ERROR] The environment variable 'SSL_CONTACT_EMAIL' is not set, please set it.`);
     process.exit();
 }
@@ -16,10 +16,16 @@ if(!process.env.SSL_CONTACT_EMAIL) {
 
 	const app = await get_app_server();
 
-	require('greenlock-express').init({
-	    packageRoot: __dirname,
-	    configDir: './greenlock.d',
-	    cluster: false,
-	   	maintainerEmail: process.env.SSL_CONTACT_EMAIL,
-	}).serve(app);
+	if (process.env.SSL_ENABLED === 'true') {
+    app.listen(80);
+  } else {
+    require("greenlock-express")
+      .init({
+        packageRoot: __dirname,
+        configDir: "./greenlock.d",
+        cluster: false,
+        maintainerEmail: process.env.SSL_CONTACT_EMAIL,
+      })
+      .serve(app);
+  }
 })();

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ if(process.env.SSL_ENABLED === 'true' && !process.env.SSL_CONTACT_EMAIL) {
 
 	const app = await get_app_server();
 
-	if (process.env.SSL_ENABLED === 'true') {
+  if (process.env.SSL_ENABLED !== 'true') {
     app.listen(80);
   } else {
     require("greenlock-express")


### PR DESCRIPTION
I've added a new env variable to disable SSL
This is usefull if you already have a reverse proxy on front.
I was in the same setting as issue  #1


Possible update:
Maybe adding an other variable to keep the secure flag on cookies.

`secure: process.env.SSL_ENABLE === 'true'` 
 