### PR TITLE
Set tag 13.5 for posgre image in docker-compose file to prevent compatibilty problem

### DIFF
--- a/api.js
+++ b/api.js
@@ -30,7 +30,7 @@ var sessions_settings_object = {
     activeDuration: 1000 * 60 * 5, // Extend for five minutes if actively used
     cookie: {
         httpOnly: true,
-        secure: true
+        secure: process.env.SSL_ENABLE === 'true'
     }
 }
 function session_wrapper_function(req, res, next) {
@@ -48,7 +48,6 @@ async function set_up_api_server(app) {
     if (!session_secret_setting) {
     	console.error(`No session secret is set, can't start API server (this really shouldn't happen...)!`);
     	throw new Error('NO_SESSION_SECRET_SET');
-    	return
     }
 
     const updated_session_settings = {

--- a/database.js
+++ b/database.js
@@ -426,8 +426,32 @@ async function initialize_correlation_api() {
 	});
 }
 
+async function wait_for_database(){
+	const sleepDurationSecond = 3
+	const sleep = () => new Promise(resolve => {setTimeout(resolve, sleepDurationSecond * 1000)})  
+	let maxTry = 10
+
+	while(maxTry--){
+		try {
+			await sequelize.authenticate();
+			return 
+		} catch (error) {
+			console.error(`Database not available, next try in ${sleepDurationSecond}s.`)
+			await sleep()
+			continue
+		}
+	}
+
+	// Database still down after 30s
+	console.error("Enable to connect to database")
+	process.exit(1)
+}
+
 async function database_init() {
 	const force = false;
+
+	// Check is the database is up
+	await wait_for_database()
 
 	// Set up database schema
 	await Promise.all([

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,17 +42,17 @@ services:
       - DATABASE_PASSWORD=${DATABASE_PASSWORD:-xsshunterexpress}
       - DATABASE_HOST=${DATABASE_HOST:-postgresdb}
       - NODE_ENV=${NODE_ENV:-production}
-    ports:
-      - "80:80"
-      - "443:443"
+    # ports:
+    #   - "80:80"
+    #  - "443:443"
     volumes:
       # Stores the SSL/TLS certificates and keys
       # in the "ssldata" directory.
       # Your certificates are automatically renewed
       # via LetsEncrypt, no extra work needed!
-      - ./ssldata:/app/greenlock.d
+      # - ./ssldata:/app/greenlock.d
       # Directory where payload fire images are stored.
-      - ./payload-fire-images:/app/payload-fire-images
+      - payloads-data:/app/payload-fire-images
     # Comment out if you're using an external SQL
     # server and have commented out the DB section.
     depends_on:
@@ -77,4 +77,9 @@ services:
       POSTGRES_DB: xsshunterexpress
       POSTGRES_PASSWORD: xsshunterexpress
     volumes:
-      - ./postgres-db-data:/var/lib/postgresql/data/pgdata
+      - db-data:/var/lib/postgresql/data/pgdata
+
+
+volumes:
+  payloads-data:
+  db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       # SSL will automatically be set up and
       #  renewed with LetsEncrypt.
       - HOSTNAME=your.host.name
-      # [REQUIRED] Email for SSL
+      - SSL_ENABLED=true
+      # [REQUIRED if SSL_ENABLED] Email for SSL
       - SSL_CONTACT_EMAIL=YourEmail@gmail.com
       # Maximum XSS callback payload size
       # This includes the webpage screenshot, DOM HTML,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,40 +8,40 @@ services:
       # the IP of the server running this service. 
       # SSL will automatically be set up and
       #  renewed with LetsEncrypt.
-      - HOSTNAME=your.host.name
-      - SSL_ENABLED=true
+      - HOSTNAME=${HOSTNAME:-your.host.name}
+      - SSL_ENABLED=${SSL_ENABLED:-true}
       # [REQUIRED if SSL_ENABLED] Email for SSL
-      - SSL_CONTACT_EMAIL=YourEmail@gmail.com
+      - SSL_CONTACT_EMAIL=${SSL_CONTACT_EMAIL:-YourEmail@gmail.com}
       # Maximum XSS callback payload size
       # This includes the webpage screenshot, DOM HTML,
       # page text, and other metadata. Note that if the
       # payload is above this limit, you won't be notified
       # of the XSS firing.
-      - MAX_PAYLOAD_UPLOAD_SIZE_MB=50
+      - MAX_PAYLOAD_UPLOAD_SIZE_MB=${MAX_PAYLOAD_UPLOAD_SIZE_MB:-50}
       # Whether or not to enable the web control panel
       # Set to "false" or remove to disable the web UI.
       # Useful for minimizing attack surface.
-      - CONTROL_PANEL_ENABLED=true
+      - CONTROL_PANEL_ENABLED=${CONTROL_PANEL_ENABLED:-true}
       # Whether or not to enable email notifications via
       # SMTP for XSS payload fires.
-      - SMTP_EMAIL_NOTIFICATIONS_ENABLED=true
-      - SMTP_HOST=smtp.gmail.com
-      - SMTP_PORT=465
-      - SMTP_USE_TLS=true
-      - SMTP_USERNAME=YourEmail@gmail.com
-      - SMTP_PASSWORD=YourEmailPassword
-      - SMTP_FROM_EMAIL=YourEmail@gmail.com
-      - SMTP_RECEIVER_EMAIL=YourEmail@gmail.com
+      - SMTP_EMAIL_NOTIFICATIONS_ENABLED=${SMTP_EMAIL_NOTIFICATIONS_ENABLED:-true}
+      - SMTP_HOST=${SMTP_HOST:-smtp.gmail.com}
+      - SMTP_PORT=${SMTP_PORT:-465}
+      - SMTP_USE_TLS=${SMTP_USE_TLS:-true}
+      - SMTP_USERNAME=${SMTP_USERNAME:-YourEmail@gmail.com}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-YourEmailPassword}
+      - SMTP_FROM_EMAIL=${SMTP_FROM_EMAIL:-YourEmail@gmail.com}
+      - SMTP_RECEIVER_EMAIL=${SMTP_RECEIVER_EMAIL:-YourEmail@gmail.com}
       # THERE IS NO NEED TO MODIFY BELOW THIS LINE
       # ------------------------------------------
       # FEEL FREE, BUT KNOW WHAT YOU'RE DOING.
       # Where XSS screenshots are stored
-      - SCREENSHOTS_DIR=/app/payload-fire-images
-      - DATABASE_NAME=xsshunterexpress
-      - DATABASE_USER=xsshunterexpress
-      - DATABASE_PASSWORD=xsshunterexpress
-      - DATABASE_HOST=postgresdb
-      - NODE_ENV=production
+      - SCREENSHOTS_DIR=${SCREENSHOTS_DIR:-/app/payload-fire-images}
+      - DATABASE_NAME=${DATABASE_NAME:-xsshunterexpress}
+      - DATABASE_USER=${DATABASE_USER:-xsshunterexpress}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD:-xsshunterexpress}
+      - DATABASE_HOST=${DATABASE_HOST:-postgresdb}
+      - NODE_ENV=${NODE_ENV:-production}
     ports:
       - "80:80"
       - "443:443"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ $ENABLE_SSL = 'true' ]]; then
+if [[ $SSL_ENABLED = 'true' ]]; then
   echo "Initializing SSL/TLS..."
   # Set up Greenlock
   # Test if --maintainer-email is required, we can set it via environment variables...

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-echo "Initializing SSL/TLS..."
-# Set up Greenlock
-# Test if --maintainer-email is required, we can set it via environment variables...
-npx greenlock init --config-dir /app/greenlock.d --maintainer-email $SSL_CONTACT_EMAIL
-npx greenlock add --subject $HOSTNAME --altnames "$HOSTNAME"
+
+if [[ $ENABLE_SSL = 'true' ]]; then
+  echo "Initializing SSL/TLS..."
+  # Set up Greenlock
+  # Test if --maintainer-email is required, we can set it via environment variables...
+  npx greenlock init --config-dir /app/greenlock.d --maintainer-email $SSL_CONTACT_EMAIL
+  npx greenlock add --subject $HOSTNAME --altnames "$HOSTNAME"
+else
+  echo "Skipping SSL initialization"
+fi
 
 echo "Starting server..."
 node server.js

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const get_app_server = require('./app.js');
 const database = require('./database.js');
 const database_init = database.database_init;
 
-if(!process.env.SSL_CONTACT_EMAIL) {
+if(process.env.SSL_ENABLED === 'true' && !process.env.SSL_CONTACT_EMAIL) {
     console.error(`[ERROR] The environment variable 'SSL_CONTACT_EMAIL' is not set, please set it.`);
     process.exit();
 }
@@ -16,10 +16,16 @@ if(!process.env.SSL_CONTACT_EMAIL) {
 
 	const app = await get_app_server();
 
-	require('greenlock-express').init({
-	    packageRoot: __dirname,
-	    configDir: './greenlock.d',
-	    cluster: false,
-	   	maintainerEmail: process.env.SSL_CONTACT_EMAIL,
-	}).serve(app);
+	if (process.env.SSL_ENABLED === 'true') {
+    app.listen(80);
+  } else {
+    require("greenlock-express")
+      .init({
+        packageRoot: __dirname,
+        configDir: "./greenlock.d",
+        cluster: false,
+        maintainerEmail: process.env.SSL_CONTACT_EMAIL,
+      })
+      .serve(app);
+  }
 })();

--- a/server.js
+++ b/server.js
@@ -11,13 +11,13 @@ if(process.env.SSL_ENABLED === 'true' && !process.env.SSL_CONTACT_EMAIL) {
 }
 
 (async () => {
-	// Ensure database is initialized.
-	await database_init();
+    // Ensure database is initialized.
+    await database_init();
 
-	const app = await get_app_server();
+    const app = await get_app_server();
 
-	if (process.env.SSL_ENABLED === 'true') {
-    app.listen(80);
+    if (process.env.SSL_ENABLED !== 'true') {
+        app.listen(80);
   } else {
     require("greenlock-express")
       .init({


### PR DESCRIPTION

With builtin docker-compose.yml, we get a compability problem at startup with the message  `The data directory was initialized by PostgreSQL version 13, which is not compatible with this version 14.1 (Debian 14.1-1.pgdg110+1)`. 
To fix it, the version of postgre can be fixed to 13.5 with above tag.
