### PR TITLE
Add SSL_ENABLED env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ To set up XSS Hunter Express, modify the [`docker-compose.yaml`](https://github.
 The following are some YAML fields (in [`docker-compose.yaml`](https://github.com/mandatoryprogrammer/xsshunter-express/blob/main/docker-compose.yml)) you'll need to modify before starting the service:
 
 * `HOSTNAME`: Set this field to your hostname you want to use for your payloads and to access the web admin panel. Often this is as short as possible (e.g. `xss.ht`) so the payload can be fit into various fields for testing. This hostname should be mapped to the IP address of your instance (via a DNS `A` record).
+
+The following are needed if you want SSL support:
+
+* `SSL_ENABLED`: Leave enabled to receive email notifications (you must set a contact email address as well).
 * `SSL_CONTACT_EMAIL`: In order to automatically set up and renew TLS/SSL certificates via [Let's Encrypt](https://letsencrypt.org/) you'll need to provide an email address.
 
 The following are needed if you want email notifications:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,13 @@ services:
     environment:
       # [REQUIRED] The hostname/domain pointed to 
       # the IP of the server running this service. 
-      # SSL will automatically be set up and
-      #  renewed with LetsEncrypt.
       - HOSTNAME=your.host.name
-      # [REQUIRED] Email for SSL
+      # Whether or not to enable SSL
+      # If set, SSL will automatically be set up and
+      # renewed with LetsEncrypt.
+      - SSL_ENABLED=true
+      # Email for SSL
+      # Required if SSL is enabled.
       - SSL_CONTACT_EMAIL=YourEmail@gmail.com
       # Maximum XSS callback payload size
       # This includes the webpage screenshot, DOM HTML,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-echo "Initializing SSL/TLS..."
-# Set up Greenlock
-# Test if --maintainer-email is required, we can set it via environment variables...
-npx greenlock init --config-dir /app/greenlock.d --maintainer-email $SSL_CONTACT_EMAIL
-npx greenlock add --subject $HOSTNAME --altnames "$HOSTNAME"
+
+if [[ "${SSL_ENABLED}" == "true" ]]; then
+  echo "Initializing SSL/TLS..."
+  # Set up Greenlock
+  # Test if --maintainer-email is required, we can set it via environment variables...
+  npx greenlock init --config-dir /app/greenlock.d --maintainer-email $SSL_CONTACT_EMAIL
+  npx greenlock add --subject $HOSTNAME --altnames "$HOSTNAME"
+fi
 
 echo "Starting server..."
 node server.js

--- a/server.js
+++ b/server.js
@@ -5,7 +5,9 @@ const get_app_server = require('./app.js');
 const database = require('./database.js');
 const database_init = database.database_init;
 
-if(!process.env.SSL_CONTACT_EMAIL) {
+const SSL_ENABLED = process.env.SSL_ENABLED === "true";
+
+if (SSL_ENABLED && !process.env.SSL_CONTACT_EMAIL) {
     console.error(`[ERROR] The environment variable 'SSL_CONTACT_EMAIL' is not set, please set it.`);
     process.exit();
 }
@@ -16,10 +18,15 @@ if(!process.env.SSL_CONTACT_EMAIL) {
 
 	const app = await get_app_server();
 
-	require('greenlock-express').init({
-	    packageRoot: __dirname,
-	    configDir: './greenlock.d',
-	    cluster: false,
-	   	maintainerEmail: process.env.SSL_CONTACT_EMAIL,
-	}).serve(app);
+	if (SSL_ENABLED) {
+		require('greenlock-express').init({
+			packageRoot: __dirname,
+			configDir: './greenlock.d',
+			cluster: false,
+			maintainerEmail: process.env.SSL_CONTACT_EMAIL,
+		}).serve(app);
+	} else {
+		app.listen(80);
+	}
+
 })();


### PR DESCRIPTION
Currently, SSL/TLS is always required, and an SSL certificate is automatically created/updated via Let's Encrypt. Here we add an option to disable that.

Obviously everyone should always use SSL, but this adds more flexibility by allowing the certificate to be obtained and managed elsewhere, such as by a reverse proxy.