### PR TITLE
Add configurable database port and database SSL/TLS options

### DIFF
--- a/database.js
+++ b/database.js
@@ -11,7 +11,15 @@ const sequelize = new Sequelize(
 	process.env.DATABASE_PASSWORD,
 	{
 		host: process.env.DATABASE_HOST,
+		port: process.env.DATABASE_PORT,
 		dialect: 'postgres',
+		ssl: process.env.DATABASE_SSL,
+		dialectOptions: {
+			ssl: {
+				require: process.env.DATABASE_SSL,
+				rejectUnauthorized: false,
+			},
+		},
 		benchmark: true,
 		logging: true
 	},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - DATABASE_USER=xsshunterexpress
       - DATABASE_PASSWORD=xsshunterexpress
       - DATABASE_HOST=postgresdb
+      - DATABASE_PORT=5432
+      - DATABASE_SSL=false
       - NODE_ENV=production
     ports:
       - "80:80"


### PR DESCRIPTION
Hi, 
First of all: thank you for all of your work with XSS Hunter & XSS Hunter express!

I recently started using managed databases in digital ocean and encountered some issues getting XSS hunter to use it. 
This small PR addresses the 2 issues I encountered: 
1. Digital ocean (and some other cloud providers) run managed databases on non-standard TCP ports. 
2. Digital ocean (and some other cloud providers) enforce SSL/TLS to remotely connect to database resources. 


