### PR TITLE
fix: increase file size limit for uploads using Multer to handle large files (ref: expressjs/multer#436)

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,8 @@ const XSS_PAYLOAD = fs.readFileSync(
 );
 
 var multer = require('multer');
-var upload = multer({ dest: '/tmp/' })
+var upload = multer({ dest: '/tmp/',limits: { fieldSize: 2 * 1024 * 1024 }})
+
 const SCREENSHOTS_DIR = path.resolve(process.env.SCREENSHOTS_DIR);
 const SCREENSHOT_FILENAME_REGEX = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\.png$/i);
 


### PR DESCRIPTION
This commit addresses an issue where large files were not being successfully uploaded to the server due to the default file size limit in Multer. To resolve this, a custom limits option was added to increase the maximum file size allowed during uploads.

The change follows the discussion and solution outlined in https://github.com/expressjs/multer/issues/436.

By increasing the file size limit, the application can now handle larger file uploads without failing. This is particularly useful for use cases where users need to upload substantial files, such as high-resolution images, videos, or other large data sets.